### PR TITLE
feat: support embedded variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ from-env is helper script that makes environment variables from a local ``.env``
 ## installation
 
 ```bash
-yarn add --dev https://github.com/krcm0209/from-env
+npm install --save-dev from-env
 ```
 
 ## usage

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ VARIABLE3=variables
 }
 ```
 
+### embedded variables replacement
+
+To enable replacing variables that are not standlone:
+
+`from-env --embedded-vars your-command --things thing1=%VARIABLE1 thing2=%VARIABLE2 --other $VARIABLE3`
+
+or
+
+`from-env your-command --things thing1=%VARIABLE1 thing2=%VARIABLE2 --other $VARIABLE3`
+
+with
+
+``.env``
+```.env
+FROM_ENV_EMBEDDED=true
+```
+
 ## alternative
 
 this also works without any package (also on windows with wsl):

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ from-env is helper script that makes environment variables from a local ``.env``
 ## installation
 
 ```bash
-npm install --save-dev from-env
+yarn add --dev https://github.com/krcm0209/from-env
 ```
 
 ## usage

--- a/bin/from-env.js
+++ b/bin/from-env.js
@@ -9,6 +9,8 @@ const spawn = require('cross-spawn'),
 require('dotenv').config({ path: require('find-config')(env_file) });
 let values = Object.assign({}, process.env);
 
+let var_pattern = /(?:[A-z]+=)?%(?<var>[A-Z]+(?:_[A-Z]+)*)/;
+
 const args = process.argv.slice(2);
 args.forEach((args__value, args__key) => {
     let res = var_pattern.exec(args__value);

--- a/bin/from-env.js
+++ b/bin/from-env.js
@@ -9,16 +9,27 @@ const spawn = require('cross-spawn'),
 require('dotenv').config({ path: require('find-config')(env_file) });
 let values = Object.assign({}, process.env);
 
+// Pattern for matching embedded variables (variables that do not stand alone)
+// Example:
+//   Before: --parameter-overrides BucketName=%BucketName
+//   After:  --parameter-overrides BucketName=my-bucket-00000
 let var_pattern = /(?:.+)?%(?<var>[A-Z]+(?:_[A-Z]+)*)/;
+let embedded_vars = false;
 
 const args = process.argv.slice(2);
+
+if (args[0] === '--embedded-vars') {
+    embedded_vars = true;
+    args.shift();
+}
+
 args.forEach((args__value, args__key) => {
     let res = var_pattern.exec(args__value);
     if (res && res.groups?.var in values) {
         if (res[0][0] === '%') {
             args[args__key] = values[args__value.substring(1)];
         }
-        else {
+        else if (embedded_vars || values['FROM_ENV_EMBEDDED'] === 'true') {
             args[args__key] = args[args__key].replace('%'+res.groups?.var, values[res.groups?.var]);
         }
     }

--- a/bin/from-env.js
+++ b/bin/from-env.js
@@ -9,7 +9,7 @@ const spawn = require('cross-spawn'),
 require('dotenv').config({ path: require('find-config')(env_file) });
 let values = Object.assign({}, process.env);
 
-let var_pattern = /(?:[A-z]+=)?%(?<var>[A-Z]+(?:_[A-Z]+)*)/;
+let var_pattern = /(?:.+)?%(?<var>[A-Z]+(?:_[A-Z]+)*)/;
 
 const args = process.argv.slice(2);
 args.forEach((args__value, args__key) => {

--- a/bin/from-env.js
+++ b/bin/from-env.js
@@ -11,8 +11,14 @@ let values = Object.assign({}, process.env);
 
 const args = process.argv.slice(2);
 args.forEach((args__value, args__key) => {
-    if (args__value[0] === '%' && args__value.substring(1) in values) {
-        args[args__key] = values[args__value.substring(1)];
+    let res = var_pattern.exec(args__value);
+    if (res && res.groups?.var in values) {
+        if (res[0][0] === '%') {
+            args[args__key] = values[args__value.substring(1)];
+        }
+        else {
+            args[args__key] = args[args__key].replace('%'+res.groups?.var, values[res.groups?.var]);
+        }
     }
 });
 


### PR DESCRIPTION
Some commands require the ability to swap in variables which are embedded in their arguments, and are not standalone arguments.

Example:
`aws cloudformation deploy --parameter-overrides parameter1=%PARAMETER1 parameter2=%PARAMETER2`

The variables being replaced in the above command are not surrounded by whitespace, and are therefore not interpreted as standalone arguments.